### PR TITLE
Fixes php 8.3 deprecation notice - creation of dynamic property

### DIFF
--- a/fields/class-swp-acf-svg-icon-v5.php
+++ b/fields/class-swp-acf-svg-icon-v5.php
@@ -9,6 +9,13 @@ if (!class_exists('swp_acf_field_svg_icon')) {
     class swp_acf_field_svg_icon extends acf_field
     {
         /**
+         * Plugin settings
+         *
+         * @var array
+         */
+        public $settings;
+
+        /**
          * __construct
          *
          * This function will setup the field type data


### PR DESCRIPTION
Addresses Deprecation notice:

```
Deprecated: Creation of dynamic property swp_acf_field_svg_icon::$settings is deprecated in .../wp-content/plugins/acf-svg-icon/fields/class-swp-acf-svg-icon-v5.php on line 57
```